### PR TITLE
Remove --disable-meta flag by detecting it from the struct automatically

### DIFF
--- a/cmd/volcago/main.go
+++ b/cmd/volcago/main.go
@@ -11,6 +11,7 @@ import (
 var (
 	isShowVersion   = flag.Bool("v", false, "print version")
 	isSubCollection = flag.Bool("sub-collection", false, "is SubCollection")
+	disableMeta     = flag.Bool("disable-meta", false, "Disable meta fields detection")
 	outputDir       = flag.String("o", "./", "Specify directory to generate code in")
 	packageName     = flag.String("p", "", "Specify the package name, default is the same as the original package")
 	collectionName  = flag.String("c", "", "Specify the collection name, default is the same as the struct name")
@@ -43,12 +44,13 @@ func main() {
 	structName := flag.Arg(0)
 
 	err = gen.Generate(structName, generator.GenerateOption{
-		OutputDir:      *outputDir,
-		PackageName:    *packageName,
-		CollectionName: *collectionName,
-		MockGenPath:    *mockGenPath,
-		MockOutputPath: *mockOutputPath,
-		Subcollection:  *isSubCollection,
+		OutputDir:                  *outputDir,
+		PackageName:                *packageName,
+		CollectionName:             *collectionName,
+		MockGenPath:                *mockGenPath,
+		MockOutputPath:             *mockOutputPath,
+		DisableMetaFieldsDetection: !*disableMeta,
+		Subcollection:              *isSubCollection,
 	})
 
 	if err != nil {

--- a/cmd/volcago/main.go
+++ b/cmd/volcago/main.go
@@ -11,7 +11,6 @@ import (
 var (
 	isShowVersion   = flag.Bool("v", false, "print version")
 	isSubCollection = flag.Bool("sub-collection", false, "is SubCollection")
-	disableMeta     = flag.Bool("disable-meta", false, "Disable meta embed")
 	outputDir       = flag.String("o", "./", "Specify directory to generate code in")
 	packageName     = flag.String("p", "", "Specify the package name, default is the same as the original package")
 	collectionName  = flag.String("c", "", "Specify the collection name, default is the same as the struct name")
@@ -49,7 +48,6 @@ func main() {
 		CollectionName: *collectionName,
 		MockGenPath:    *mockGenPath,
 		MockOutputPath: *mockOutputPath,
-		UseMetaField:   !*disableMeta,
 		Subcollection:  *isSubCollection,
 	})
 

--- a/examples/history.go
+++ b/examples/history.go
@@ -1,6 +1,6 @@
 package examples
 
-//go:generate ../bin/volcago -disable-meta -sub-collection -c histories History
+//go:generate ../bin/volcago -sub-collection -c histories History
 
 // History - Task sub-collection
 type History struct {

--- a/examples/task.go
+++ b/examples/task.go
@@ -2,7 +2,7 @@ package examples
 
 import "time"
 
-//go:generate ../bin/volcago -disable-meta Task
+//go:generate ../bin/volcago Task
 
 type Inner struct {
 	A string `firestore:"a"`

--- a/generator/emulator_test.go
+++ b/generator/emulator_test.go
@@ -20,7 +20,7 @@ func execTest(t *testing.T) {
 	}
 }
 
-func run(t *testing.T, structName string, useMeta, subCollection bool) {
+func run(t *testing.T, structName string, subCollection bool) {
 	t.Helper()
 
 	gen, err := NewGenerator(".")
@@ -30,7 +30,6 @@ func run(t *testing.T, structName string, useMeta, subCollection bool) {
 	}
 
 	opt := NewDefaultGenerateOption()
-	opt.UseMetaField = useMeta
 	opt.Subcollection = subCollection
 
 	if err := gen.Generate(structName, opt); err != nil {
@@ -50,8 +49,8 @@ func TestGenerator(t *testing.T) {
 			tr.Fatalf("chdir failed: %+v", err)
 		}
 
-		run(t, "Task", false, false)
-		run(t, "Lock", true, false)
+		run(t, "Task", false)
+		run(t, "Lock", false)
 
 		execTest(tr)
 	})
@@ -61,9 +60,9 @@ func TestGenerator(t *testing.T) {
 			tr.Fatalf("chdir failed: %+v", err)
 		}
 
-		run(t, "Task", false, false)
+		run(t, "Task", false)
 
-		run(t, "SubTask", false, true)
+		run(t, "SubTask", true)
 
 		execTest(tr)
 	})

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -47,7 +47,6 @@ type GenerateOption struct {
 	CollectionName string
 	MockGenPath    string
 	MockOutputPath string
-	UseMetaField   bool
 	Subcollection  bool
 }
 
@@ -57,7 +56,6 @@ func NewDefaultGenerateOption() GenerateOption {
 		OutputDir:      ".",
 		MockGenPath:    "mockgen",
 		MockOutputPath: "mock/mock_{{ .GeneratedFileName }}/mock_{{ .GeneratedFileName }}.go",
-		UseMetaField:   true,
 	}
 }
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -57,7 +57,7 @@ func NewDefaultGenerateOption() GenerateOption {
 		OutputDir:                  ".",
 		MockGenPath:                "mockgen",
 		MockOutputPath:             "mock/mock_{{ .GeneratedFileName }}/mock_{{ .GeneratedFileName }}.go",
-		DisableMetaFieldsDetection: true,
+		DisableMetaFieldsDetection: false,
 	}
 }
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -42,20 +42,22 @@ func NewGenerator(dir string) (*Generator, error) {
 
 // GenerateOption is a parameter to generate repository
 type GenerateOption struct {
-	OutputDir      string
-	PackageName    string
-	CollectionName string
-	MockGenPath    string
-	MockOutputPath string
-	Subcollection  bool
+	OutputDir                  string
+	PackageName                string
+	CollectionName             string
+	MockGenPath                string
+	MockOutputPath             string
+	DisableMetaFieldsDetection bool
+	Subcollection              bool
 }
 
 // NewDefaultGenerateOption returns a default GenerateOption
 func NewDefaultGenerateOption() GenerateOption {
 	return GenerateOption{
-		OutputDir:      ".",
-		MockGenPath:    "mockgen",
-		MockOutputPath: "mock/mock_{{ .GeneratedFileName }}/mock_{{ .GeneratedFileName }}.go",
+		OutputDir:                  ".",
+		MockGenPath:                "mockgen",
+		MockOutputPath:             "mock/mock_{{ .GeneratedFileName }}/mock_{{ .GeneratedFileName }}.go",
+		DisableMetaFieldsDetection: true,
 	}
 }
 

--- a/generator/structGenerator.go
+++ b/generator/structGenerator.go
@@ -116,29 +116,35 @@ func isIgnoredField(tags *structtag.Tags) bool {
 }
 
 func (g *structGenerator) hasMetaFields() bool {
+	const (
+		stringType = "string"
+		timeType   = "time.Time"
+		intType    = "int"
+	)
+
 	expectedFields := map[string]struct {
 		Type string
 	}{
 		"CreatedAt": {
-			Type: "time.Time",
+			Type: timeType,
 		},
 		"CreatedBy": {
-			Type: "string",
+			Type: stringType,
 		},
 		"UpdatedAt": {
-			Type: "time.Time",
+			Type: timeType,
 		},
 		"UpdatedBy": {
-			Type: "string",
+			Type: stringType,
 		},
 		"DeletedAt": {
-			Type: "*time.Time",
+			Type: "*" + timeType,
 		},
 		"DeletedBy": {
-			Type: "string",
+			Type: stringType,
 		},
 		"Version": {
-			Type: "int",
+			Type: intType,
 		},
 	}
 
@@ -153,13 +159,13 @@ func (g *structGenerator) hasMetaFields() bool {
 			}
 			return "*" + s
 		case *types.String:
-			return "string"
+			return stringType
 		case *types.Date:
-			return "time.Time"
+			return timeType
 		case *types.Number:
 			switch t.RawType {
 			case gotypes.Int:
-				return "int"
+				return intType
 			}
 		}
 

--- a/generator/structGenerator.go
+++ b/generator/structGenerator.go
@@ -43,10 +43,13 @@ func newStructGenerator(typ *types.Object, structName, appVersion string, opt Ge
 		return nil, xerrors.Errorf("failed to call IsSamePath: %w", err)
 	}
 
-	hasMetaFields, err := g.hasMetaFields()
+	var hasMetaFields bool
+	if !opt.DisableMetaFieldsDetection {
+		hasMetaFields, err = g.hasMetaFields()
 
-	if err != nil {
-		return nil, xerrors.Errorf("meta fields are invalid: %w", err)
+		if err != nil {
+			return nil, xerrors.Errorf("meta fields are invalid: %w", err)
+		}
 	}
 
 	name := g.typ.Position.Filename


### PR DESCRIPTION
`--disable-meta` を強制的にmeta fieldとしての扱いを無効にするオプションとして残しました。
というのも、Metaを使っていないにも関わらず、別の目的で追加したVersionなどのFieldがMetaとして認識して生成に失敗する可能性などがあったためです。