### PR TITLE
Fix a bug that a wrong UpdateParam is generated, Fix a bug that --disable-meta flag is inversed

### DIFF
--- a/cmd/volcago/main.go
+++ b/cmd/volcago/main.go
@@ -49,7 +49,7 @@ func main() {
 		CollectionName:             *collectionName,
 		MockGenPath:                *mockGenPath,
 		MockOutputPath:             *mockOutputPath,
-		DisableMetaFieldsDetection: !*disableMeta,
+		DisableMetaFieldsDetection: *disableMeta,
 		Subcollection:              *isSubCollection,
 	})
 

--- a/generator/structGenerator.go
+++ b/generator/structGenerator.go
@@ -256,8 +256,6 @@ func (g *structGenerator) parseTypeImpl(rawKey, firestoreKey string, obj *types.
 		if typeName == "" {
 			obj := e.Type.(*types.Object)
 
-			rawKey = strings.Join(sliceutil.RemoveEmpty([]string{rawKey, e.RawName}), ".")
-
 			tags, err := structtag.Parse(e.RawTag)
 			if err != nil {
 				firestoreKey = strings.Join(sliceutil.RemoveEmpty([]string{firestoreKey, e.RawName}), ".")
@@ -267,6 +265,7 @@ func (g *structGenerator) parseTypeImpl(rawKey, firestoreKey string, obj *types.
 				firestoreKey = strings.Join(sliceutil.RemoveEmpty([]string{firestoreKey, t.Name}), ".")
 			}
 
+			rawKey := strings.Join(sliceutil.RemoveEmpty([]string{rawKey, e.RawName}), ".")
 			if err := g.parseTypeImpl(rawKey, firestoreKey, obj); err != nil {
 				return xerrors.Errorf("failed to parse %s: %w", e.RawName, err)
 			}

--- a/generator/structGenerator.go
+++ b/generator/structGenerator.go
@@ -265,8 +265,8 @@ func (g *structGenerator) parseTypeImpl(rawKey, firestoreKey string, obj *types.
 				firestoreKey = strings.Join(sliceutil.RemoveEmpty([]string{firestoreKey, t.Name}), ".")
 			}
 
-			rawKey := strings.Join(sliceutil.RemoveEmpty([]string{rawKey, e.RawName}), ".")
-			if err := g.parseTypeImpl(rawKey, firestoreKey, obj); err != nil {
+			fieldRawKey := strings.Join(sliceutil.RemoveEmpty([]string{rawKey, e.RawName}), ".")
+			if err := g.parseTypeImpl(fieldRawKey, firestoreKey, obj); err != nil {
 				return xerrors.Errorf("failed to parse %s: %w", e.RawName, err)
 			}
 			continue


### PR DESCRIPTION
Closes #5 

rawKeyを誤って上書きしていたため他のフィールドにあると誤って判定されていました。
また、 #6 の修正になるかはまだ確認できていませんが、 `--disable-meta` が!で反転して渡されていたためデフォルトで全てのstructでmetaのdetectionが無効化されてしまっていました・・・(--disable-metaを渡すと有効になるという・・・)