### PR TITLE
Fix call of reflect.Value.Type on zero Value

### DIFF
--- a/examples/different_dir/misc_gen.go
+++ b/examples/different_dir/misc_gen.go
@@ -150,6 +150,9 @@ func updateBuilder(v, param interface{}) map[string]firestore.Update {
 			if isReservedType(fv) {
 				break
 			}
+			if pfv.Interface() == nil {
+				continue
+			}
 			for key, update := range updateBuilder(fv.Interface(), pfv.Interface()) {
 				update.FieldPath = append(firestore.FieldPath{path}, update.FieldPath...)
 

--- a/examples/misc_gen.go
+++ b/examples/misc_gen.go
@@ -150,6 +150,9 @@ func updateBuilder(v, param interface{}) map[string]firestore.Update {
 			if isReservedType(fv) {
 				break
 			}
+			if pfv.Interface() == nil {
+				continue
+			}
 			for key, update := range updateBuilder(fv.Interface(), pfv.Interface()) {
 				update.FieldPath = append(firestore.FieldPath{path}, update.FieldPath...)
 

--- a/generator/templates/misc.go.tmpl
+++ b/generator/templates/misc.go.tmpl
@@ -150,6 +150,9 @@ func updateBuilder(v, param interface{}) map[string]firestore.Update {
 			if isReservedType(fv) {
 				break
 			}
+			if pfv.Interface() == nil {
+				continue
+			}
 			for key, update := range updateBuilder(fv.Interface(), pfv.Interface()) {
 				update.FieldPath = append(firestore.FieldPath{path}, update.FieldPath...)
 

--- a/generator/testfiles/auto/misc_gen.go
+++ b/generator/testfiles/auto/misc_gen.go
@@ -150,6 +150,9 @@ func updateBuilder(v, param interface{}) map[string]firestore.Update {
 			if isReservedType(fv) {
 				break
 			}
+			if pfv.Interface() == nil {
+				continue
+			}
 			for key, update := range updateBuilder(fv.Interface(), pfv.Interface()) {
 				update.FieldPath = append(firestore.FieldPath{path}, update.FieldPath...)
 

--- a/generator/testfiles/misc/misc.go
+++ b/generator/testfiles/misc/misc.go
@@ -119,6 +119,9 @@ func updateBuilder(v, param interface{}) map[string]firestore.Update {
 			if isReservedType(fv) {
 				break
 			}
+			if pfv.Interface() == nil {
+				continue
+			}
 			for key, update := range updateBuilder(fv.Interface(), pfv.Interface()) {
 				update.FieldPath = append(firestore.FieldPath{path}, update.FieldPath...)
 

--- a/generator/testfiles/misc/misc_test.go
+++ b/generator/testfiles/misc/misc_test.go
@@ -169,6 +169,17 @@ func Test_updater(t *testing.T) {
 				{FieldPath: firestore.FieldPath{"version"}, Value: 1},
 			},
 		},
+		{
+			args: args{
+				v: article{},
+				param: &articleUpdateParam{
+					Page: "section",
+				},
+			},
+			want: []firestore.Update{
+				{FieldPath: firestore.FieldPath{"page"}, Value: "section"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/generator/testfiles/not_auto/misc_gen.go
+++ b/generator/testfiles/not_auto/misc_gen.go
@@ -150,6 +150,9 @@ func updateBuilder(v, param interface{}) map[string]firestore.Update {
 			if isReservedType(fv) {
 				break
 			}
+			if pfv.Interface() == nil {
+				continue
+			}
 			for key, update := range updateBuilder(fv.Interface(), pfv.Interface()) {
 				update.FieldPath = append(firestore.FieldPath{path}, update.FieldPath...)
 


### PR DESCRIPTION
- Closes #109

```
--- FAIL: Test_updater (0.00s)
    --- PASS: Test_updater/#00 (0.00s)
    --- FAIL: Test_updater/#01 (0.00s)
panic: reflect: call of reflect.Value.Type on zero Value [recovered]
	panic: reflect: call of reflect.Value.Type on zero Value

goroutine 29 [running]:
testing.tRunner.func1.2({0x15fc2c0, 0xc00012ac60})
	/Users/aska/local/go-1.18/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/Users/aska/local/go-1.18/src/testing/testing.go:1392 +0x39f
panic({0x15fc2c0, 0xc00012ac60})
	/Users/aska/local/go-1.18/src/runtime/panic.go:838 +0x207
reflect.Value.Type({0x0?, 0x0?, 0x15f24e0?})
	/Users/aska/local/go-1.18/src/reflect/value.go:2453 +0x12e
github.com/go-generalize/volcago/generator/testfiles/misc.updateBuilder({0x1687300?, 0xc0001403c0?}, {0x0?, 0x0})
	/Users/aska/go/src/github.com/go-generalize/volcago/generator/testfiles/misc/misc.go:86 +0x238
github.com/go-generalize/volcago/generator/testfiles/misc.updateBuilder({0x1675900?, 0xc0001403c0?}, {0x15b5ce0?, 0xc00038c6e0})
	/Users/aska/go/src/github.com/go-generalize/volcago/generator/testfiles/misc/misc.go:122 +0x6ea
github.com/go-generalize/volcago/generator/testfiles/misc.updater({0x1675900, 0xc0001403c0}, {0x15b5ce0, 0xc00038c6e0})
	/Users/aska/go/src/github.com/go-generalize/volcago/generator/testfiles/misc/misc.go:26 +0x85
github.com/go-generalize/volcago/generator/testfiles/misc.Test_updater.func1(0xc00040a820)
	/Users/aska/go/src/github.com/go-generalize/volcago/generator/testfiles/misc/misc_test.go:188 +0x54
testing.tRunner(0xc00040a820, 0xc000132280)
	/Users/aska/local/go-1.18/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/Users/aska/local/go-1.18/src/testing/testing.go:1486 +0x35f
FAIL	github.com/go-generalize/volcago/generator/testfiles/misc	0.185s
```