### PR TITLE
Go Releaserのアップデート

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.18
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
           workdir: cmd/volcago
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/volcago/.goreleaser.yml
+++ b/cmd/volcago/.goreleaser.yml
@@ -1,4 +1,5 @@
 project_name: volcago
+version: 2
 
 env:
   - GO111MODULE=on
@@ -17,13 +18,13 @@ builds:
       - CGO_ENABLED=0
 
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: darwin
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
<!-- This is a template. Please rewrite to the necessary contents when creating the PR. -->
<!-- If there is an issue, enter it. -->
- Update Go Releaser Action to v6
- Fix ``.goreleaser.yml`` (which Closes #224 )

<!-- ## Overview -->
<!-- Please write the purpose of this PR and the outline of implementation. -->
Updated `.goreleaser.yml` replacement since `archives.replacements` is deprecated at `2023-06-06`.
Also updated Go Releaser Action to v6. Since this PR solves deprecation no migration needed.

`goreleaser.yml` の`archives.replacements`がdeprecatedだったので解決しました (https://goreleaser.com/deprecations/#archivesreplacements )。
また、deprecatedが解決されたためGo Releaser Actionのバージョンをv6にアップデートしました。併せて`.yml`のversionも`2`を明示的に指定してあります。