### PR TITLE
Support Basic type pointer

### DIFF
--- a/examples/different_dir/misc_gen.go
+++ b/examples/different_dir/misc_gen.go
@@ -44,7 +44,21 @@ type PagingResult struct {
 
 func isReservedType(value reflect.Value) bool {
 	switch value.Interface().(type) {
-	case time.Time, *time.Time,
+	case int, *int,
+		int8, *int8,
+		int16, *int16,
+		int32, *int32,
+		int64, *int64,
+		uint, *uint,
+		uint8, *uint8,
+		uint16, *uint16,
+		uint32, *uint32,
+		uint64, *uint64,
+		float32, *float32,
+		float64, *float64,
+		bool, *bool,
+		string, *string,
+		time.Time, *time.Time,
 		latlng.LatLng, *latlng.LatLng,
 		firestore.DocumentRef, *firestore.DocumentRef:
 		return true

--- a/examples/misc_gen.go
+++ b/examples/misc_gen.go
@@ -44,7 +44,21 @@ type PagingResult struct {
 
 func isReservedType(value reflect.Value) bool {
 	switch value.Interface().(type) {
-	case time.Time, *time.Time,
+	case int, *int,
+		int8, *int8,
+		int16, *int16,
+		int32, *int32,
+		int64, *int64,
+		uint, *uint,
+		uint8, *uint8,
+		uint16, *uint16,
+		uint32, *uint32,
+		uint64, *uint64,
+		float32, *float32,
+		float64, *float64,
+		bool, *bool,
+		string, *string,
+		time.Time, *time.Time,
 		latlng.LatLng, *latlng.LatLng,
 		firestore.DocumentRef, *firestore.DocumentRef:
 		return true

--- a/examples/repository/misc_gen.go
+++ b/examples/repository/misc_gen.go
@@ -44,7 +44,21 @@ type PagingResult struct {
 
 func isReservedType(value reflect.Value) bool {
 	switch value.Interface().(type) {
-	case time.Time, *time.Time,
+	case int, *int,
+		int8, *int8,
+		int16, *int16,
+		int32, *int32,
+		int64, *int64,
+		uint, *uint,
+		uint8, *uint8,
+		uint16, *uint16,
+		uint32, *uint32,
+		uint64, *uint64,
+		float32, *float32,
+		float64, *float64,
+		bool, *bool,
+		string, *string,
+		time.Time, *time.Time,
 		latlng.LatLng, *latlng.LatLng,
 		firestore.DocumentRef, *firestore.DocumentRef:
 		return true

--- a/generator/templates/misc.go.tmpl
+++ b/generator/templates/misc.go.tmpl
@@ -44,7 +44,21 @@ type PagingResult struct {
 
 func isReservedType(value reflect.Value) bool {
 	switch value.Interface().(type) {
-	case time.Time, *time.Time,
+	case int, *int,
+        int8, *int8,
+        int16, *int16,
+        int32, *int32,
+        int64, *int64,
+        uint, *uint,
+        uint8, *uint8,
+        uint16, *uint16,
+        uint32, *uint32,
+        uint64, *uint64,
+        float32, *float32,
+        float64, *float64,
+        bool, *bool,
+        string, *string,
+        time.Time, *time.Time,
 		latlng.LatLng, *latlng.LatLng,
 		firestore.DocumentRef, *firestore.DocumentRef:
 		return true

--- a/generator/testfiles/auto/misc_gen.go
+++ b/generator/testfiles/auto/misc_gen.go
@@ -44,7 +44,21 @@ type PagingResult struct {
 
 func isReservedType(value reflect.Value) bool {
 	switch value.Interface().(type) {
-	case time.Time, *time.Time,
+	case int, *int,
+		int8, *int8,
+		int16, *int16,
+		int32, *int32,
+		int64, *int64,
+		uint, *uint,
+		uint8, *uint8,
+		uint16, *uint16,
+		uint32, *uint32,
+		uint64, *uint64,
+		float32, *float32,
+		float64, *float64,
+		bool, *bool,
+		string, *string,
+		time.Time, *time.Time,
 		latlng.LatLng, *latlng.LatLng,
 		firestore.DocumentRef, *firestore.DocumentRef:
 		return true

--- a/generator/testfiles/misc/misc.go
+++ b/generator/testfiles/misc/misc.go
@@ -109,6 +109,9 @@ func updateBuilder(v, param interface{}) map[string]firestore.Update {
 		}
 
 		pfv := pv.FieldByName(ft.Name)
+		if pfv.Interface() == nil && !isReservedType(fv) && fv.Kind() == reflect.Ptr {
+			pfv.Set(reflect.New(fv.Type().Elem()))
+		}
 
 		switch fv.Kind() {
 		case reflect.Ptr:

--- a/generator/testfiles/misc/misc.go
+++ b/generator/testfiles/misc/misc.go
@@ -13,7 +13,21 @@ import (
 
 func isReservedType(value reflect.Value) bool {
 	switch value.Interface().(type) {
-	case time.Time, *time.Time,
+	case int, *int,
+		int8, *int8,
+		int16, *int16,
+		int32, *int32,
+		int64, *int64,
+		uint, *uint,
+		uint8, *uint8,
+		uint16, *uint16,
+		uint32, *uint32,
+		uint64, *uint64,
+		float32, *float32,
+		float64, *float64,
+		bool, *bool,
+		string, *string,
+		time.Time, *time.Time,
 		latlng.LatLng, *latlng.LatLng,
 		firestore.DocumentRef, *firestore.DocumentRef:
 		return true

--- a/generator/testfiles/not_auto/misc_gen.go
+++ b/generator/testfiles/not_auto/misc_gen.go
@@ -44,7 +44,21 @@ type PagingResult struct {
 
 func isReservedType(value reflect.Value) bool {
 	switch value.Interface().(type) {
-	case time.Time, *time.Time,
+	case int, *int,
+		int8, *int8,
+		int16, *int16,
+		int32, *int32,
+		int64, *int64,
+		uint, *uint,
+		uint8, *uint8,
+		uint16, *uint16,
+		uint32, *uint32,
+		uint64, *uint64,
+		float32, *float32,
+		float64, *float64,
+		bool, *bool,
+		string, *string,
+		time.Time, *time.Time,
 		latlng.LatLng, *latlng.LatLng,
 		firestore.DocumentRef, *firestore.DocumentRef:
 		return true


### PR DESCRIPTION
`Repository#StrictUpdate` を下記のような基本タイプのポインタをサポートするようにしてみました。
ご確認していただけますと幸いです。

```golang
type Sample struct {
	Foo *int `firestore:"foo"`
}
```

現在のバージョンですと下記のようなpanicが発生しました。
```
--- FAIL: Test_updateBuilder/#00 (0.00s)
panic: reflect: NumField of non-struct type int [recovered]
	panic: reflect: NumField of non-struct type int

goroutine 54 [running]:
testing.tRunner.func1.2({0x100d1c4a0, 0x140003dfb20})
	go/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
	go/src/testing/testing.go:1634 +0x33c
panic({0x100d1c4a0?, 0x140003dfb20?})
	go/src/runtime/panic.go:770 +0x124
reflect.(*rtype).NumField(0x100cfe1a0?)
	go/src/reflect/type.go:769 +0x6c
github.com/go-generalize/volcago/generator/testfiles/misc.updateBuilder({0x100cfe1a0?, 0x140003ec888?}, {0x100d1c6e0, 0x100cacb18})
	volcago/generator/testfiles/misc/misc.go:88 +0x220
github.com/go-generalize/volcago/generator/testfiles/misc.updateBuilder({0x100e01ca0?, 0x14000172900?}, {0x100cfd960, 0x140003f2580})
	volcago/generator/testfiles/misc/misc.go:128 +0x77c
github.com/go-generalize/volcago/generator/testfiles/misc.Test_updateBuilder.func1(0x140003f6ea0)
	volcago/generator/testfiles/misc/misc_test.go:320 +0x40
testing.tRunner(0x140003f6ea0, 0x140003f4b00)
	go/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 53
	go/src/testing/testing.go:1742 +0x318
```